### PR TITLE
add movie crawler and secret_key for movie api

### DIFF
--- a/movie_crawler/movie_crawl.py
+++ b/movie_crawler/movie_crawl.py
@@ -7,27 +7,40 @@ movies = []
 date = datetime.now()
 date_ago = date + timedelta(days=-1)
 date_fit = date_ago.strftime('%Y%m%d')
+#당일 기준으로는 데이터를 끌어올수 없어서 전날 기준으로 데이터를 수집
+api_key = secret.KEY['secret_key']
+#API 키 가져오기
 
-secret = secret.KEY['secret_key']
+currentPath = os.getcwd()
+file_path = currentPath + '/movie_list_'+date_fit+'.csv'
+csv_file = open(file_path, 'w', newline="")
+
 
 def start_crawl():
-    url = 'http://www.kobis.or.kr/kobisopenapi/webservice/rest/boxoffice/searchDailyBoxOfficeList.json?key='+secret+'&targetDt='+date_fit
+    url = 'http://www.kobis.or.kr/kobisopenapi/webservice/rest/boxoffice/searchDailyBoxOfficeList.json?key='+api_key+'&targetDt='+date_fit
 
     res = ul.urlopen(url, timeout=5)
+
     data = res.read()
-    d = json.loads(data)
+
+    data_body = json.loads(data)
     
-    for b in d['boxOfficeResult']['dailyBoxOfficeList']:
-       movies.append({'rank':b['rank'],'movieNm':b['movieNm'],'movieCd':b['movieCd'],'salesAmt':b['salesAmt'],'audiCnt':b['audiCnt']})
+    for props in data_body['boxOfficeResult']['dailyBoxOfficeList']:
+       movies.append({
+                        'rank':props['rank'],
+                        'movieNm':props['movieNm'],
+                        'movieCd':props['movieCd'],
+                        'salesAmt':props['salesAmt'],
+                        'audiCnt':props['audiCnt']
+       })
+#크롤링 끝 가져온 데이터 csv로 저장    
     
-    
-    currentPath = os.getcwd()
-    file_path = currentPath + '/movie_list_'+date_fit+'.csv'
     csv_columns = ['rank','movieNm','movieCd','salesAmt','audiCnt']
     
-    csv_file = open(file_path, 'w', newline="")
-    csvwriter = csv.DictWriter(csv_file, fieldnames=csv_columns)
-    csvwriter.writeheader()
+    csvwriter = csv.DictWriter(csv_file, fieldnames=csv_columns);
+    
+    csvwriter.writeheader();
+    
     for movie_list in movies:
         csvwriter.writerow(movie_list)
     csv_file.close()

--- a/movie_crawler/movie_crawl.py
+++ b/movie_crawler/movie_crawl.py
@@ -6,9 +6,7 @@ from datetime import datetime, timedelta
 movies = []
 
 date = datetime.now()
-
 date_ago = date + timedelta(days=-1)
-
 date_fit = date_ago.strftime('%Y%m%d')
 
 #당일 기준으로는 데이터를 끌어올수 없어서 전날 기준으로 데이터를 수집
@@ -18,19 +16,14 @@ api_key = secret.KEY['secret_key']
 #API 키 가져오기
 
 currentPath = os.getcwd()
-
 file_path = currentPath + '/movie_list_'+date_fit+'.csv'
-
 csv_file = open(file_path, 'w', newline="")
-
 
 def start_crawl():
     url = 'http://www.kobis.or.kr/kobisopenapi/webservice/rest/boxoffice/searchDailyBoxOfficeList.json?key='+api_key+'&targetDt='+date_fit
 
     res = ul.urlopen(url, timeout=5)
-
     data = res.read()
-
     data_body = json.loads(data)
     
     for props in data_body['boxOfficeResult']['dailyBoxOfficeList']:
@@ -41,12 +34,12 @@ def start_crawl():
                         'salesAmt':props['salesAmt'],
                         'audiCnt':props['audiCnt']
        })
+
 #크롤링 끝 가져온 데이터 csv로 저장    
-    
+   
     csv_columns = ['rank','movieNm','movieCd','salesAmt','audiCnt']
     
     csvwriter = csv.DictWriter(csv_file, fieldnames=csv_columns);
-    
     csvwriter.writeheader();
     
     for movie_list in movies:

--- a/movie_crawler/movie_crawl.py
+++ b/movie_crawler/movie_crawl.py
@@ -4,15 +4,23 @@ from datetime import datetime, timedelta
 
 
 movies = []
+
 date = datetime.now()
+
 date_ago = date + timedelta(days=-1)
+
 date_fit = date_ago.strftime('%Y%m%d')
+
 #당일 기준으로는 데이터를 끌어올수 없어서 전날 기준으로 데이터를 수집
+
 api_key = secret.KEY['secret_key']
+
 #API 키 가져오기
 
 currentPath = os.getcwd()
+
 file_path = currentPath + '/movie_list_'+date_fit+'.csv'
+
 csv_file = open(file_path, 'w', newline="")
 
 
@@ -43,6 +51,7 @@ def start_crawl():
     
     for movie_list in movies:
         csvwriter.writerow(movie_list)
+    
     csv_file.close()
 
     

--- a/movie_crawler/movie_crawl.py
+++ b/movie_crawler/movie_crawl.py
@@ -1,0 +1,36 @@
+import urllib.request as ul
+import json, secret, csv, os
+from datetime import datetime, timedelta
+
+
+movies = []
+date = datetime.now()
+date_ago = date + timedelta(days=-1)
+date_fit = date_ago.strftime('%Y%m%d')
+
+secret = secret.KEY['secret_key']
+
+def start_crawl():
+    url = 'http://www.kobis.or.kr/kobisopenapi/webservice/rest/boxoffice/searchDailyBoxOfficeList.json?key='+secret+'&targetDt='+date_fit
+
+    res = ul.urlopen(url, timeout=5)
+    data = res.read()
+    d = json.loads(data)
+    
+    for b in d['boxOfficeResult']['dailyBoxOfficeList']:
+       movies.append({'rank':b['rank'],'movieNm':b['movieNm'],'movieCd':b['movieCd'],'salesAmt':b['salesAmt'],'audiCnt':b['audiCnt']})
+    
+    
+    currentPath = os.getcwd()
+    file_path = currentPath + '/movie_list_'+date_fit+'.csv'
+    csv_columns = ['rank','movieNm','movieCd','salesAmt','audiCnt']
+    
+    csv_file = open(file_path, 'w', newline="")
+    csvwriter = csv.DictWriter(csv_file, fieldnames=csv_columns)
+    csvwriter.writeheader()
+    for movie_list in movies:
+        csvwriter.writerow(movie_list)
+    csv_file.close()
+
+    
+start_crawl()

--- a/movie_crawler/secret.py
+++ b/movie_crawler/secret.py
@@ -1,4 +1,0 @@
-#secret.py
-KEY = {
-   'secret_key':'5bf39a36f35b2265ffaf46ae565ba365',
-}

--- a/movie_crawler/secret.py
+++ b/movie_crawler/secret.py
@@ -1,0 +1,4 @@
+#secret.py
+KEY = {
+   'secret_key':'5bf39a36f35b2265ffaf46ae565ba365',
+}


### PR DESCRIPTION
# movie_crawler  생성
## 한국영화진흥원 오픈 API로부터 일별 영화 순위 채집 코드 생성.
- 랭킹,  제목,  제작일, 수익, 일별 관객수 로 데이터 수집함.
- 조회 후 바로 csv로 저장하는 코드.
- 외부(아마도 루이지)  임포트 후 실행 가능하게 함수 처리 완료.
